### PR TITLE
Update TagCloud.js

### DIFF
--- a/TagCloud.js
+++ b/TagCloud.js
@@ -161,6 +161,12 @@ Ext.define('Ext.TagCloud', {
 		
 		this.fireEvent('tagselect', this, this.getDataSource().getAt(index), index);
 		
+		//create event object if not exists
+		if( Ext.isEmpty( Ext.EventObject ) === true ){
+			
+			Ext.EventObject = new Ext.EventObjectImpl(e);
+		}//if..
+		
 		// Prevent the link href from being followed
 		Ext.EventObject.stopEvent(e);
 	},


### PR DESCRIPTION
Ext.EventObject does not support directly after EXT 5.1.x.
So the solution for it to create an instance of EventObjectImpl.